### PR TITLE
Improve performance when using ascii_only strings

### DIFF
--- a/lib/mb_string/core_ext/string.rb
+++ b/lib/mb_string/core_ext/string.rb
@@ -1,19 +1,21 @@
 require 'unicode/display_width'
-# TODO: asciiかどうか判定する？
 class String
   def mb_ljust(width, pad_str = ' ')
+    return ljust(width, pad_str) if ascii_only? && pad_str.ascii_only?
     mb_execute(width) do |pad_size|
       self + mb_build_padding(pad_size, pad_str)
     end
   end
 
   def mb_rjust(width, pad_str = ' ')
+    return rjust(width, pad_str) if ascii_only? && pad_str.ascii_only?
     mb_execute(width) do |pad_size|
       mb_build_padding(pad_size, pad_str, is_append_right: false) + self
     end
   end
 
   def mb_center(width, pad_str = ' ')
+    return center(width, pad_str) if ascii_only? && pad_str.ascii_only?
     mb_execute(width) do |pad_size|
       left_pad_size = pad_size / 2
       right_pad_size = pad_size - left_pad_size


### PR DESCRIPTION
It's faster using default methods when ascii only strings.

## benchmark code
```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report('mb_ljust') do
    'aaaaaaaaaaaaa'.mb_ljust(100, 'x')
  end
  x.report('mb_ljust') do
    'あああああああ'.mb_ljust(100, 'x')
  end

  x.report('mb_rjust') do
    'aaaaaaaaaaaaa'.mb_rjust(100, 'x')
  end
  x.report('mb_rjust') do
    'あああああああ'.mb_rjust(100, 'x')
  end

  x.report('mb_center') do
    'aaaaaaaaaaaaa'.mb_center(100, 'x')
  end
  x.report('mb_center') do
    'あああああああ'.mb_center(100, 'x')
  end
end
```

## before
```
Calculating -------------------------------------
            mb_ljust     4.657k i/100ms
            mb_ljust     9.464k i/100ms
            mb_rjust     5.111k i/100ms
            mb_rjust     9.713k i/100ms
           mb_center     4.330k i/100ms
           mb_center     7.581k i/100ms
-------------------------------------------------
            mb_ljust     52.477k (± 6.4%) i/s -    265.449k
            mb_ljust    103.611k (± 7.6%) i/s -    520.520k
            mb_rjust     53.533k (± 5.7%) i/s -    270.883k
            mb_rjust    100.028k (± 7.5%) i/s -    505.076k
           mb_center     46.389k (± 5.8%) i/s -    233.820k
           mb_center     79.625k (± 5.4%) i/s -    401.793k
```

## after
```
Calculating -------------------------------------
            mb_ljust    66.441k i/100ms
            mb_ljust     8.195k i/100ms
            mb_rjust    73.815k i/100ms
            mb_rjust     9.607k i/100ms
           mb_center    71.558k i/100ms
           mb_center     7.448k i/100ms
-------------------------------------------------
            mb_ljust      1.355M (±11.3%) i/s -      6.644M
            mb_ljust    105.043k (± 7.5%) i/s -    524.480k
            mb_rjust      1.349M (± 9.8%) i/s -      6.717M
            mb_rjust    102.561k (± 7.9%) i/s -    509.171k
           mb_center      1.257M (±14.7%) i/s -      6.154M
           mb_center     78.529k (±10.9%) i/s -    394.744k
```